### PR TITLE
Add local chatbots in iframe layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,12 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div class="container">
-    <h1>Menú de Chatbots de Prueba</h1>
-    <div id="chatbotMenu" class="chatbot-menu"></div>
+  <div class="layout">
+    <div class="container">
+      <h1>Menú de Chatbots de Prueba</h1>
+      <div id="chatbotMenu" class="chatbot-menu"></div>
+    </div>
+    <iframe id="chatbotFrame" class="chatbot-frame"></iframe>
   </div>
 
   <script src="scripts.js"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -1,4 +1,6 @@
 const chatbots = [
+  { name: "Agente Comprador", url: "chat_comprador.html", icon: "🏠" },
+  { name: "Chatbot FAQs", url: "chat_faqs.html", icon: "❓" },
   { name: "Chatbot de Ventas", url: "https://ejemplo.com/chatbot-ventas", icon: "🛒" },
   { name: "Chatbot de Soporte", url: "https://ejemplo.com/chatbot-soporte", icon: "🛠️" },
   { name: "Chatbot de Finanzas", url: "https://ejemplo.com/chatbot-finanzas", icon: "💰" },
@@ -8,17 +10,26 @@ const chatbots = [
 
 function loadChatbotMenu() {
   const menuContainer = document.getElementById("chatbotMenu");
+  const frame = document.getElementById("chatbotFrame");
 
   if (!menuContainer) {
     console.error("Elemento con ID 'chatbotMenu' no encontrado.");
     return;
   }
 
-  chatbots.forEach(bot => {
+  chatbots.forEach((bot, index) => {
     const button = document.createElement("button");
     button.className = "chatbot-button";
-    button.onclick = () => window.open(bot.url, "_blank");
     button.innerHTML = `<span class="emoji">${bot.icon}</span> ${bot.name}`;
+    button.addEventListener("click", () => {
+      document.querySelectorAll(".chatbot-button.active").forEach(b => b.classList.remove("active"));
+      button.classList.add("active");
+      if (frame) frame.src = bot.url;
+    });
+    if (index === 0 && frame) {
+      frame.src = bot.url;
+      button.classList.add("active");
+    }
     menuContainer.appendChild(button);
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -2,20 +2,23 @@ body {
   font-family: 'Segoe UI', sans-serif;
   background-color: #f0f2f5;
   margin: 0;
-  padding: 40px;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  height: 100vh;
+}
+
+.layout {
+  display: flex;
+  width: 100%;
+  height: 100%;
 }
 
 .container {
   background: white;
-  padding: 30px 40px;
-  border-radius: 12px;
+  padding: 20px;
   box-shadow: 0 8px 20px rgba(0,0,0,0.1);
-  max-width: 700px;
-  width: 100%;
+  width: 250px;
   text-align: center;
+  overflow-y: auto;
 }
 
 h1 {
@@ -25,9 +28,8 @@ h1 {
 
 .chatbot-menu {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 20px;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .chatbot-button {
@@ -51,6 +53,15 @@ h1 {
   background-color: #357ABD;
 }
 
+.chatbot-button.active {
+  background-color: #357ABD;
+}
+
 .chatbot-button span.emoji {
   font-size: 24px;
+}
+
+.chatbot-frame {
+  flex: 1;
+  border: none;
 }


### PR DESCRIPTION
## Summary
- embed a left-hand menu and right-side iframe in the layout
- include chat_comprador.html and chat_faqs.html as first options
- show selected chatbot inside the iframe
- style menu buttons vertically and mark the active one

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d1b0bab30832a8f5e6cc6a968d34e