### PR TITLE
Add Asistente Virtual chatbot

### DIFF
--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -32,11 +32,14 @@
   <header class="bg-green-600 text-white flex items-center justify-between px-4 py-3 shadow-md gap-2 flex-wrap">
     <h1 class="text-lg font-semibold tracking-wide select-none">Asistente Virtual</h1>
     <div class="flex items-center gap-2 flex-wrap">
-      <label for="endpointSelect" class="text-sm text-white/80">Endpoint:</label>
+      <label for="endpointSelect" class="text-sm text-white/80">Entorno:</label>
       <select id="endpointSelect" class="text-gray-900 rounded-lg px-2 py-1 text-sm focus:outline-none">
-        <option value="https://api.inmovilla.com/v3/bot/test">Test</option>
+        <option value="https://api.inmovilla.com/v3/bot/test">Producci&oacute;n</option>
+        <option value="https://test.inmovilla.com/v3/bot/test">Test</option>
+        <option value="http://localhost/app/api/v2/bot/test">Localhost</option>
       </select>
-      <input id="tokenInput" type="text" placeholder="JWT Token" class="text-gray-900 rounded-lg px-2 py-1 text-sm focus:outline-none" />
+      <span id="currentEndpoint" class="text-xs text-white/80 break-all"></span>
+      <input id="tokenInput" type="text" placeholder="JWT Token" title="Para obtener el JWT, accede al CRM, inicia sesi&oacute;n, abre el inspector de Chrome, ve a Aplicaci&oacute;n y copia la cookie llamada 'jwt'." class="text-gray-900 rounded-lg px-2 py-1 text-sm focus:outline-none" />
     </div>
   </header>
 
@@ -53,6 +56,7 @@
     const TOKEN_STORAGE_KEY = 'virtualToken';
 
     const endpointSelect = document.getElementById('endpointSelect');
+    const endpointDisplay = document.getElementById('currentEndpoint');
     const tokenInput = document.getElementById('tokenInput');
     const chatBox = document.getElementById('chat');
     const textarea = document.getElementById('message');
@@ -60,9 +64,11 @@
 
     endpointSelect.value = localStorage.getItem(ENDPOINT_STORAGE_KEY) || endpointSelect.value;
     tokenInput.value = localStorage.getItem(TOKEN_STORAGE_KEY) || '';
+    endpointDisplay.textContent = endpointSelect.value;
 
     endpointSelect.addEventListener('change', () => {
       localStorage.setItem(ENDPOINT_STORAGE_KEY, endpointSelect.value);
+      endpointDisplay.textContent = endpointSelect.value;
     });
 
     tokenInput.addEventListener('input', () => {

--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Asistente Virtual</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+  <style>
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: url("https://wallpapers.com/images/high/whatsapp-chat-doodle-patterns-jyd5uvep2fdwjl97.webp") center/cover no-repeat;
+      opacity: 0.08;
+      filter: blur(1px);
+      pointer-events: none;
+      z-index: -1;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .spinner {
+      width: 1.25rem;
+      height: 1.25rem;
+      border: 3px solid transparent;
+      border-top-color: #22c55e;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+  </style>
+</head>
+<body class="h-screen flex flex-col font-sans bg-[#f4f6f8]">
+  <header class="bg-green-600 text-white flex items-center justify-between px-4 py-3 shadow-md gap-2 flex-wrap">
+    <h1 class="text-lg font-semibold tracking-wide select-none">Asistente Virtual</h1>
+    <div class="flex items-center gap-2 flex-wrap">
+      <label for="endpointSelect" class="text-sm text-white/80">Endpoint:</label>
+      <select id="endpointSelect" class="text-gray-900 rounded-lg px-2 py-1 text-sm focus:outline-none">
+        <option value="https://api.inmovilla.com/v3/bot/test">Test</option>
+      </select>
+      <input id="tokenInput" type="text" placeholder="JWT Token" class="text-gray-900 rounded-lg px-2 py-1 text-sm focus:outline-none" />
+    </div>
+  </header>
+
+  <main id="chat" class="flex-1 overflow-y-auto p-4 space-y-4"></main>
+
+  <footer class="p-3 bg-white/95 backdrop-blur-md shadow-inner flex items-end gap-3">
+    <textarea id="message" rows="1" placeholder="Escribe tu mensaje…" class="flex-1 resize-none rounded-xl border border-gray-300 p-3 focus:outline-none max-h-40 overflow-y-auto placeholder:text-gray-400 text-sm"></textarea>
+    <button id="send" class="bg-green-600 hover:bg-green-700 text-white rounded-xl px-5 py-3 font-medium shadow-md">Enviar</button>
+  </footer>
+
+  <script src="appendTextOrImages.js"></script>
+  <script>
+    const ENDPOINT_STORAGE_KEY = 'virtualEndpoint';
+    const TOKEN_STORAGE_KEY = 'virtualToken';
+
+    const endpointSelect = document.getElementById('endpointSelect');
+    const tokenInput = document.getElementById('tokenInput');
+    const chatBox = document.getElementById('chat');
+    const textarea = document.getElementById('message');
+    const sendBtn = document.getElementById('send');
+
+    endpointSelect.value = localStorage.getItem(ENDPOINT_STORAGE_KEY) || endpointSelect.value;
+    tokenInput.value = localStorage.getItem(TOKEN_STORAGE_KEY) || '';
+
+    endpointSelect.addEventListener('change', () => {
+      localStorage.setItem(ENDPOINT_STORAGE_KEY, endpointSelect.value);
+    });
+
+    tokenInput.addEventListener('input', () => {
+      localStorage.setItem(TOKEN_STORAGE_KEY, tokenInput.value);
+    });
+
+    function addMessage(text, from = 'user') {
+      const bubble = document.createElement('div');
+      const alignRight = from === 'user';
+      bubble.className = `${alignRight ? 'self-end bg-green-600 text-white' : 'bg-white text-gray-900'} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[90%] whitespace-pre-wrap`;
+      appendTextOrImages(bubble, text);
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'flex flex-col' + (alignRight ? ' items-end' : ' items-start');
+      wrapper.appendChild(bubble);
+      chatBox.appendChild(wrapper);
+      chatBox.scrollTop = chatBox.scrollHeight;
+    }
+
+    function addSpinner() {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'flex items-center gap-2';
+      wrapper.id = 'spinnerWrapper';
+      const spin = document.createElement('div');
+      spin.className = 'spinner';
+      wrapper.appendChild(spin);
+      const txt = document.createElement('span');
+      txt.className = 'text-sm text-gray-500';
+      txt.textContent = 'Esperando respuesta…';
+      wrapper.appendChild(txt);
+      chatBox.appendChild(wrapper);
+      chatBox.scrollTop = chatBox.scrollHeight;
+    }
+
+    function removeSpinner() {
+      const el = document.getElementById('spinnerWrapper');
+      el && el.remove();
+    }
+
+    async function sendMessage() {
+      const text = textarea.value.trim();
+      if (!text) return;
+      textarea.value = '';
+      textarea.style.height = 'auto';
+      addMessage(text, 'user');
+      addSpinner();
+
+      const headers = { 'Content-Type': 'application/json' };
+      const token = tokenInput.value.trim();
+      if (token) headers['Authorization'] = 'Bearer ' + token;
+      const body = {
+        fromUser: 33,
+        toUser: 225130,
+        agencyId: 6713,
+        fromAgencyId: 413,
+        message: text
+      };
+
+      try {
+        const resp = await fetch(endpointSelect.value, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body)
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (Array.isArray(data)) {
+          data.forEach(part => {
+            const msg = part[0]?.content;
+            if (msg) addMessage(msg, 'bot');
+          });
+        } else {
+          addMessage('⚠️ Respuesta inesperada del servidor', 'bot');
+        }
+      } catch (err) {
+        addMessage('⚠️ ' + err.message, 'bot');
+      } finally {
+        removeSpinner();
+      }
+    }
+
+    sendBtn.addEventListener('click', sendMessage);
+    textarea.addEventListener('keydown', e => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        sendMessage();
+      }
+    });
+    textarea.addEventListener('input', () => {
+      textarea.style.height = 'auto';
+      textarea.style.height = textarea.scrollHeight + 'px';
+    });
+  </script>
+</body>
+</html>

--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -76,7 +76,7 @@
       localStorage.setItem(TOKEN_STORAGE_KEY, tokenInput.value);
     });
 
-    function addMessage(text, from = 'user') {
+    function addMessage(text, from = 'user', query = null, json = null) {
       const bubble = document.createElement('div');
       const alignRight = from === 'user';
       bubble.className = `${alignRight ? 'self-end bg-green-600 text-white' : 'bg-white text-gray-900'} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[90%] whitespace-pre-wrap`;
@@ -85,6 +85,36 @@
       const wrapper = document.createElement('div');
       wrapper.className = 'flex flex-col' + (alignRight ? ' items-end' : ' items-start');
       wrapper.appendChild(bubble);
+
+      if (from === 'bot' && (query || json)) {
+        const icons = document.createElement('div');
+        icons.className = 'flex gap-2 text-sm text-gray-500 mt-1';
+
+        function addToggle(iconText, content) {
+          let box;
+          const icon = document.createElement('span');
+          icon.textContent = iconText;
+          icon.className = 'cursor-pointer select-none';
+          icon.addEventListener('click', () => {
+            if (box) {
+              box.remove();
+              box = null;
+            } else {
+              box = document.createElement('pre');
+              box.className = 'whitespace-pre-wrap bg-gray-100 p-2 rounded-md text-xs max-w-[90%] overflow-auto';
+              box.textContent = typeof content === 'object' ? JSON.stringify(content, null, 2) : content;
+              icons.after(box);
+            }
+          });
+          icons.appendChild(icon);
+        }
+
+        if (query) addToggle('📝', query);
+        if (json) addToggle('📄', json);
+
+        wrapper.appendChild(icons);
+      }
+
       chatBox.appendChild(wrapper);
       chatBox.scrollTop = chatBox.scrollHeight;
     }
@@ -128,6 +158,10 @@
         message: text
       };
 
+      if (/test\.inmovilla\.com/.test(endpointSelect.value) || /localhost/.test(endpointSelect.value)) {
+        body.mode = 'debug';
+      }
+
       try {
         const resp = await fetch(endpointSelect.value, {
           method: 'POST',
@@ -138,8 +172,11 @@
         const data = await resp.json();
         if (Array.isArray(data)) {
           data.forEach(part => {
-            const msg = part[0]?.content;
-            if (msg) addMessage(msg, 'bot');
+            const first = part[0] || {};
+            const msg = first.content;
+            const query = first.query;
+            const jsonResp = first.json;
+            if (msg) addMessage(msg, 'bot', query, jsonResp);
           });
         } else {
           addMessage('⚠️ Respuesta inesperada del servidor', 'bot');

--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -39,7 +39,8 @@
         <option value="http://localhost/app/api/v2/bot/test">Localhost</option>
       </select>
       <span id="currentEndpoint" class="text-xs text-white/80 break-all"></span>
-      <input id="tokenInput" type="text" placeholder="JWT Token" title="Para obtener el JWT, accede al CRM, inicia sesi&oacute;n, abre el inspector de Chrome, ve a Aplicaci&oacute;n y copia la cookie llamada 'jwt'." class="text-gray-900 rounded-lg px-2 py-1 text-sm focus:outline-none" />
+      <input id="tokenInput" type="text" placeholder="JWT Token" class="text-gray-900 rounded-lg px-2 py-1 text-sm focus:outline-none" />
+      <span class="text-white/80 cursor-help" title="Para obtener el JWT, accede al CRM, inicia sesi&oacute;n, abre el inspector de Chrome, ve a Aplicaci&oacute;n y copia la cookie llamada 'jwt'.">&#9432;</span>
     </div>
   </header>
 

--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,7 @@
 const chatbots = [
   { name: "Chatbot FAQs", url: "chat_faqs.html", icon: "❓" },
-  { name: "Agente para Comprador", url: "chat_comprador.html", icon: "🏠" }
+  { name: "Agente para Comprador", url: "chat_comprador.html", icon: "🏠" },
+  { name: "Asistente Virtual", url: "chat_virtual.html", icon: "🤖" }
 ];
 
 function loadChatbotMenu() {


### PR DESCRIPTION
## Summary
- add new `Asistente Virtual` option in the main menu
- implement new chatbot page `chat_virtual.html`
  - includes endpoint selector and JWT token input stored in localStorage
  - sends POST requests with fixed payload
  - displays multiple bot messages from API response

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4e6fcfb4832aa8f07f702da62c8b