### PR TITLE
Fix express server routing

### DIFF
--- a/api/proxy/inmovilla.js
+++ b/api/proxy/inmovilla.js
@@ -1,0 +1,26 @@
+export default async function handler(req, res) {
+  const target = req.query.target;
+  if (!target) {
+    res.status(400).json({ error: 'Falta el parámetro target' });
+    return;
+  }
+  const method = req.method;
+  const headers = { ...req.headers };
+  delete headers.host;
+  delete headers.origin;
+  delete headers.referer;
+  const options = { method, headers };
+  if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+    options.body = JSON.stringify(req.body);
+  }
+  try {
+    const response = await fetch(target, options);
+    const data = await response.text();
+    res.status(response.status);
+    res.setHeader('content-type', response.headers.get('content-type') || 'text/plain');
+    res.end(data);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Error al conectar con la API de Inmovilla' });
+  }
+}

--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -174,6 +174,15 @@
           headers,
           body: JSON.stringify(body)
         });
+        if (resp.status === 401) {
+          addMessage(
+            '⚠️ Error 401: el JWT es inválido o ha caducado. ' +
+              'En el CRM, inicia sesión, abre el inspector de Chrome, ve a "Aplicación" y ' +
+              'copia la cookie llamada "jwt" para obtener un nuevo token.',
+            'bot'
+          );
+          return;
+        }
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         if (Array.isArray(data)) {

--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -75,7 +75,7 @@
     // Redefinir la función para obtener el endpoint real
     function getRealEndpoint() {
       // Siempre usar el proxy y pasar el endpoint real como parámetro
-      return '/proxy/inmovilla?target=' + encodeURIComponent(endpointSelect.value);
+      return '/api/proxy/inmovilla?target=' + encodeURIComponent(endpointSelect.value);
     }
 
     tokenInput.addEventListener('input', () => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "devDependencies": {},
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "node-fetch": "^2.6.9"
   },
   "scripts": {
     "test": "node test/runTests.js"

--- a/server.js
+++ b/server.js
@@ -4,11 +4,7 @@ const fetch = require('node-fetch');
 const cors = require('cors');
 
 async function handleFaqEntry(req, res) {
-  let body = '';
-  for await (const chunk of req) {
-    body += chunk;
-  }
-  const data = body ? JSON.parse(body) : {};
+  const data = req.body || {};
   try {
     const response = await fetch('https://procesos.inmovilla.com/peticionesexternas/chatbot/postFaqRapida.php', {
       method: 'POST',
@@ -67,14 +63,9 @@ app.all('/proxy/inmovilla', async (req, res) => {
   }
 });
 
-const httpServer = http.createServer((req, res) => {
-  if (req.method === 'POST' && req.url === '/api/faq-entry') {
-    handleFaqEntry(req, res);
-  } else {
-    res.statusCode = 404;
-    res.end('Not Found');
-  }
-});
+app.post('/api/faq-entry', handleFaqEntry);
+
+const httpServer = http.createServer(app);
 
 if (require.main === module) {
   const PORT = process.env.PORT || 3000;

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.get('/proxy/inmovilla', async (req, res) => {
+app.get(['/proxy/inmovilla', '/api/proxy/inmovilla'], async (req, res) => {
   try {
     const response = await fetch('https://api.inmovilla.com/v3/bot/test');
     const data = await response.json();
@@ -35,7 +35,7 @@ app.get('/proxy/inmovilla', async (req, res) => {
   }
 });
 
-app.all('/proxy/inmovilla', async (req, res) => {
+app.all(['/proxy/inmovilla', '/api/proxy/inmovilla'], async (req, res) => {
   try {
     const target = req.query.target;
     if (!target) {


### PR DESCRIPTION
## Summary
- adjust `handleFaqEntry` to use Express request body
- mount `/api/faq-entry` as an Express route
- use the Express app to serve all routes

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686f6c09dc38832aa15a2683e28e2816