### PR TITLE
Enable assistant selection via URL

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -10,6 +10,14 @@ function loadChatbotMenu() {
   const menuContainer = document.getElementById("chatbotMenu");
   const frame = document.getElementById("chatbotFrame");
 
+  const params = new URLSearchParams(window.location.search);
+  const botParam = params.get("bot");
+  let initialIndex = 0;
+  if (botParam) {
+    const found = chatbots.findIndex((b) => b.url === botParam);
+    if (found >= 0) initialIndex = found;
+  }
+
   if (!menuContainer) {
     console.error("Elemento con ID 'chatbotMenu' no encontrado.");
     return;
@@ -28,8 +36,11 @@ function loadChatbotMenu() {
       document.querySelectorAll(".chatbot-button.active").forEach(b => b.classList.remove("active"));
       button.classList.add("active");
       if (frame) frame.src = bot.url;
+      const params = new URLSearchParams(window.location.search);
+      params.set("bot", bot.url);
+      window.history.pushState({}, "", window.location.pathname + "?" + params.toString());
     });
-    if (index === 0 && frame && bot.active) {
+    if (index === initialIndex && frame && bot.active) {
       frame.src = bot.url;
       button.classList.add("active");
     }


### PR DESCRIPTION
## Summary
- allow direct loading of a chatbot by reading `?bot=<url>` query parameter
- push a new `?bot` parameter to the address bar when a chatbot is selected

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686f7b3639bc832a99717a7d211be986