### PR TITLE
Update version display

### DIFF
--- a/chat_comprador.html
+++ b/chat_comprador.html
@@ -456,6 +456,5 @@ d.toLocaleTimeString("es-ES", {
 
       init();
     </script>
-    <script src="version.js"></script>
   </body>
 </html>

--- a/chat_faqs.html
+++ b/chat_faqs.html
@@ -571,6 +571,5 @@ d.toLocaleTimeString("es-ES", {
 
       init();
     </script>
-    <script src="version.js"></script>
   </body>
 </html>

--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -226,6 +226,5 @@
       textarea.style.height = textarea.scrollHeight + 'px';
     });
   </script>
-  <script src="version.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatbots",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "devDependencies": {},
   "dependencies": {
     "express": "^4.18.2",

--- a/version.js
+++ b/version.js
@@ -1,7 +1,7 @@
 (function() {
-  const APP_VERSION = '1.0.0';
+  const APP_VERSION = '1.0.1';
   const style = document.createElement('style');
-  style.textContent = '.version-info{position:fixed;bottom:5px;left:5px;font-size:10px;color:#555;}';
+  style.textContent = '.version-info{position:fixed;bottom:5px;right:5px;font-size:10px;color:#555;}';
   document.head.appendChild(style);
   function addVersionInfo() {
     const info = document.createElement('div');


### PR DESCRIPTION
## Summary
- remove version info script from individual assistant pages
- move version to bottom-right of menu only
- bump version to 1.0.1

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686f82d88a7c832a872bd91241b7851f