### PR TITLE
Improve debug display for bot messages

### DIFF
--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -49,6 +49,9 @@
   </header>
 
   <main id="chat" class="flex-1 overflow-y-auto p-4 space-y-4"></main>
+  <div id="modalOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+    <pre id="modalBox" class="bg-white p-4 rounded-lg max-h-[90%] overflow-auto whitespace-pre-wrap text-sm w-full max-w-3xl"></pre>
+  </div>
 
   <footer class="p-3 bg-white/95 backdrop-blur-md shadow-inner flex items-end gap-3">
     <textarea id="message" rows="1" placeholder="Escribe tu mensaje…" class="flex-1 resize-none rounded-xl border border-gray-300 p-3 focus:outline-none max-h-40 overflow-y-auto placeholder:text-gray-400 text-sm"></textarea>
@@ -68,6 +71,8 @@
     const chatBox = document.getElementById('chat');
     const textarea = document.getElementById('message');
     const sendBtn = document.getElementById('send');
+    const modalOverlay = document.getElementById('modalOverlay');
+    const modalBox = document.getElementById('modalBox');
 
     endpointSelect.value = localStorage.getItem(ENDPOINT_STORAGE_KEY) || endpointSelect.value;
     tokenInput.value = localStorage.getItem(TOKEN_STORAGE_KEY) || '';
@@ -93,6 +98,27 @@
       localStorage.setItem(TOKEN_STORAGE_KEY, tokenInput.value);
     });
 
+    function openModal(content) {
+      try {
+        if (typeof content === 'string' && content.trim().startsWith('{')) {
+          modalBox.textContent = JSON.stringify(JSON.parse(content), null, 2);
+        } else if (typeof content === 'object') {
+          modalBox.textContent = JSON.stringify(content, null, 2);
+        } else {
+          modalBox.textContent = content;
+        }
+      } catch {
+        modalBox.textContent = content;
+      }
+      modalOverlay.classList.remove('hidden');
+    }
+
+    modalOverlay.addEventListener('click', e => {
+      if (e.target === modalOverlay) {
+        modalOverlay.classList.add('hidden');
+      }
+    });
+
     function addMessage(text, from = 'user', query = null, json = null) {
       const bubble = document.createElement('div');
       const alignRight = from === 'user';
@@ -108,21 +134,10 @@
         icons.className = 'flex gap-2 text-sm text-gray-500 mt-1';
 
         function addToggle(iconText, content) {
-          let box;
           const icon = document.createElement('span');
           icon.textContent = iconText;
           icon.className = 'cursor-pointer select-none';
-          icon.addEventListener('click', () => {
-            if (box) {
-              box.remove();
-              box = null;
-            } else {
-              box = document.createElement('pre');
-              box.className = 'whitespace-pre-wrap bg-gray-100 p-2 rounded-md text-xs max-w-[90%] overflow-auto';
-              box.textContent = typeof content === 'object' ? JSON.stringify(content, null, 2) : content;
-              icons.after(box);
-            }
-          });
+          icon.addEventListener('click', () => openModal(content));
           icons.appendChild(icon);
         }
 
@@ -198,12 +213,17 @@
         const data = await resp.json();
         if (Array.isArray(data)) {
           data.forEach(part => {
-            const first = part[0] || {};
+            const first = Array.isArray(part) ? (part[0] || {}) : part || {};
             const msg = first.content;
             const query = first.query;
             const jsonResp = first.json;
             if (msg) addMessage(msg, 'bot', query, jsonResp);
           });
+        } else if (data && typeof data === 'object') {
+          const msg = data.content;
+          const query = data.query;
+          const jsonResp = data.json;
+          if (msg) addMessage(msg, 'bot', query, jsonResp);
         } else {
           addMessage('⚠️ Respuesta inesperada del servidor', 'bot');
         }


### PR DESCRIPTION
## Summary
- add a centered modal overlay for viewing JSON and query data
- show modal when the 📝 and 📄 icons are clicked
- better handle content that arrives as arrays or plain objects

## Testing
- `npm test --silent` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686f890d966c832aa30cea93b56a39d6