### PR TITLE
Handle localhost endpoint on frontend

### DIFF
--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -106,8 +106,13 @@
 
     // Redefinir la función para obtener el endpoint real
     function getRealEndpoint() {
-      // Siempre usar el proxy y pasar el endpoint real como parámetro
-      return '/api/proxy/inmovilla?target=' + encodeURIComponent(endpointSelect.value);
+      const val = endpointSelect.value;
+      // Si el destino es localhost, llamar directamente desde el front
+      if (/^https?:\/\/localhost\b/.test(val) || /^https?:\/\/127\.0\.0\.1\b/.test(val)) {
+        return val;
+      }
+      // Para el resto de URLs usar el proxy
+      return '/api/proxy/inmovilla?target=' + encodeURIComponent(val);
     }
 
     tokenInput.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- allow direct fetch for localhost in `chat_virtual.html`

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68775778e770832a842e6cea81a2501a