### PR TITLE
Refactor fetch usage

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 const http = require('http');
 const express = require('express');
-const fetch = require('node-fetch');
+// Prefer the built-in fetch when available to reduce dependencies
+// and fall back to the node-fetch package for older Node versions
+const fetch = global.fetch || require('node-fetch');
 const cors = require('cors');
 
 async function handleFaqEntry(req, res) {


### PR DESCRIPTION
## Summary
- prefer built-in `fetch` when available and fall back to `node-fetch`

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68789e2298d0832aab6e9a0b3f41d208