### PR TITLE
Enable custom user IDs and hide buyer bot

### DIFF
--- a/chat_faqs.html
+++ b/chat_faqs.html
@@ -285,38 +285,59 @@
         });
       }
 
-      function changeActiveUser(id) {
-        if (id === "new") {
-          const name = prompt("Nombre del nuevo usuario:");
-          if (!name) {
-            userSelect.value = loadUsers()[0].id; // restaurar selección previa
-            return;
+        function changeActiveUser(id) {
+          if (id === "new") {
+            const name = prompt("Nombre del nuevo usuario:");
+            if (!name) {
+              userSelect.value = loadUsers()[0].id; // restaurar selección previa
+              return;
+            }
+            const users = loadUsers();
+            let newId = generateUserId();
+            const customId = prompt("ID del nuevo usuario:", newId);
+            if (customId) newId = customId.trim();
+            if (users.some((u) => u.id === newId)) {
+              alert("Ya existe un usuario con ese ID.");
+              userSelect.value = loadUsers()[0].id;
+              return;
+            }
+            users.push({ id: newId, name });
+            saveUsers(users);
+            renderUserOptions();
+            userSelect.value = newId;
+            id = newId;
           }
-          const users = loadUsers();
-          const newId = generateUserId();
-          users.push({ id: newId, name });
-          saveUsers(users);
-          renderUserOptions();
-          userSelect.value = newId;
-          id = newId;
-        }
         loadHistoryIntoChat(id);
         resetConversationState();
         disableUserButtons(false);
       }
 
-      renameBtn.addEventListener("click", () => {
-        const currentId = userSelect.value;
-        const users = loadUsers();
-        const idx = users.findIndex((u) => u.id === currentId);
-        if (idx === -1) return;
-        const newName = prompt("Nuevo nombre:", users[idx].name);
-        if (!newName) return;
-        users[idx].name = newName;
-        saveUsers(users);
-        renderUserOptions();
-        userSelect.value = currentId;
-      });
+        renameBtn.addEventListener("click", () => {
+          const currentId = userSelect.value;
+          const users = loadUsers();
+          const idx = users.findIndex((u) => u.id === currentId);
+          if (idx === -1) return;
+          const newName = prompt("Nuevo nombre:", users[idx].name);
+          if (!newName) return;
+          let newId = prompt("Nuevo ID:", currentId) || currentId;
+          newId = newId.trim();
+          if (newId !== currentId && users.some((u) => u.id === newId)) {
+            alert("Ya existe un usuario con ese ID.");
+            return;
+          }
+          if (newId !== currentId) {
+            const hist = loadHistory(currentId);
+            localStorage.setItem(
+              HISTORY_PREFIX + newId,
+              JSON.stringify(hist)
+            );
+            localStorage.removeItem(HISTORY_PREFIX + currentId);
+          }
+          users[idx] = { id: newId, name: newName };
+          saveUsers(users);
+          renderUserOptions();
+          userSelect.value = newId;
+        });
 
       deleteBtn.addEventListener("click", () => {
         const currentId = userSelect.value;

--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,6 @@
 const chatbots = [
   { name: "Chatbot FAQs", url: "chat_faqs.html", icon: "fa-circle-question", active: true },
-  { name: "Agente para Comprador", url: "chat_comprador.html", icon: "fa-house", active: true },
+  { name: "Agente para Comprador", url: "chat_comprador.html", icon: "fa-house", active: false },
   { name: "Agente para Vendedor", url: "chat_vendedor.html", icon: "fa-user-tie", active: false },
   { name: "Agente para Inquilino", url: "chat_inquilino.html", icon: "fa-user", active: false },
   { name: "Asistente Virtual", url: "chat_virtual.html", icon: "fa-robot", active: true }


### PR DESCRIPTION
## Summary
- allow entering a custom user ID when creating a new user in the FAQ chatbot
- allow changing the user ID when renaming a user
- deactivate the buyer chatbot entry

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688388f282d0832aa191f92cdb091a13