### PR TITLE
Fix chat bubble width

### DIFF
--- a/chat_comprador.html
+++ b/chat_comprador.html
@@ -313,7 +313,7 @@ d.toLocaleTimeString("es-ES", {
       function addMessage(text, from = "user", date = new Date(), save = true, query = null, json = null) {
         const bubble = document.createElement("div");
         const alignRight = from === "user";
-        bubble.className = `${alignRight ? "self-end bg-green-600 text-white" : "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[90%] whitespace-pre-wrap`;
+        bubble.className = `${alignRight ? "self-end bg-green-600 text-white" : "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[calc(100%-3rem)] whitespace-pre-line break-words`;
         appendTextOrImages(bubble, text);
 
         const wrapper = document.createElement("div");
@@ -335,7 +335,7 @@ d.toLocaleTimeString("es-ES", {
                 box = null;
               } else {
                 box = document.createElement("pre");
-                box.className = "whitespace-pre-wrap bg-gray-100 dark:bg-gray-800 p-2 rounded-md text-xs max-w-[90%] overflow-auto";
+                box.className = "whitespace-pre-wrap bg-gray-100 dark:bg-gray-800 p-2 rounded-md text-xs max-w-[calc(100%-3rem)] overflow-auto";
                 box.textContent = typeof content === "object" ? JSON.stringify(content, null, 2) : content;
                 icons.after(box);
               }

--- a/chat_faqs.html
+++ b/chat_faqs.html
@@ -407,7 +407,7 @@ d.toLocaleTimeString("es-ES", {
       function addMessage(text, from = "user", date = new Date(), save = true, query = null, json = null) {
         const bubble = document.createElement("div");
         const alignRight = from === "user";
-        bubble.className = `${alignRight ? "self-end bg-green-600 text-white" : "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[90%] whitespace-pre-wrap`;
+        bubble.className = `${alignRight ? "self-end bg-green-600 text-white" : "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[calc(100%-3rem)] whitespace-pre-line break-words`;
         bubble.dataset.raw = text;
         bubble.dataset.from = from;
         appendTextOrImages(bubble, text);
@@ -445,7 +445,7 @@ d.toLocaleTimeString("es-ES", {
                 box = null;
               } else {
                 box = document.createElement("pre");
-                box.className = "whitespace-pre-wrap bg-gray-100 dark:bg-gray-800 p-2 rounded-md text-xs max-w-[90%] overflow-auto";
+                box.className = "whitespace-pre-wrap bg-gray-100 dark:bg-gray-800 p-2 rounded-md text-xs max-w-[calc(100%-3rem)] overflow-auto";
                 box.textContent = typeof content === "object" ? JSON.stringify(content, null, 2) : content;
                 icons.after(box);
               }

--- a/chat_virtual.html
+++ b/chat_virtual.html
@@ -189,7 +189,7 @@
     function addMessage(text, from = 'user', query = null, json = null, error = null) {
       const bubble = document.createElement('div');
       const alignRight = from === 'user';
-      bubble.className = `${alignRight ? 'self-end bg-green-600 text-white' : 'bg-white text-gray-900'} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[90%] whitespace-pre-wrap`;
+      bubble.className = `${alignRight ? 'self-end bg-green-600 text-white' : 'bg-white text-gray-900'} rounded-2xl py-2 px-4 shadow-md inline-block max-w-[calc(100%-3rem)] whitespace-pre-line break-words`;
       appendTextOrImages(bubble, text);
 
       const wrapper = document.createElement('div');


### PR DESCRIPTION
## Summary
- keep message and icons inline by using `calc(100% - 3rem)` width
- show messages without extra spacing using `whitespace-pre-line break-words`

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68823f8571a0832ab952778f865a8b78